### PR TITLE
Ensure 2 character minimum width in format()

### DIFF
--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -98,7 +98,7 @@ def upload_callback(filename):
     def inner(size, total):
         sys.stderr.write("\r")
         if total > 0:
-            sys.stderr.write("{: <4.0%}\t{}\t\t({: {width}}/{: {width}})".format(size / float(total), filename, size, total, width=int(math.log(total, 10))-2))
+            sys.stderr.write("{: <4.0%}\t{}\t\t({: {width}}/{: {width}})".format(size / float(total), filename, size, total, width=max(int(math.log(total, 10))-2, 2)))
         else:
             sys.stderr.write("?%\t{}".format(filename))
 


### PR DESCRIPTION
A file that is less than 100 bytes (i.e. 74 bytes) will mean that the formatted width is 0 or lower, throwing "ValueError: Invalid conversion specification".