### PR TITLE
boto3 support

### DIFF
--- a/bigstore/backends/s3.py
+++ b/bigstore/backends/s3.py
@@ -5,9 +5,9 @@ except ImportError:
     pass
 
 class S3Backend(object):
-    def __init__(self, bucket_name, key, secret):
+    def __init__(self, bucket_name, key=None, secret=None, profile_name=None):
         self.bucket = bucket_name
-        self.session = boto3.Session(aws_access_key_id=key, aws_secret_access_key=secret)
+        self.session = boto3.Session(aws_access_key_id=key, aws_secret_access_key=secret, profile_name=profile_name)
         self.s3_client = self.session.client('s3')
 
     @property

--- a/bigstore/backends/s3.py
+++ b/bigstore/backends/s3.py
@@ -1,29 +1,39 @@
 try:
-    import boto
+    import boto3
+    import botocore
 except ImportError:
     pass
 
 class S3Backend(object):
-    def __init__(self, key, secret, bucket_name):
-        self.access_key = key
-        self.secret = secret
+    def __init__(self, bucket_name, key, secret):
         self.bucket = bucket_name
-        self.conn = boto.connect_s3(key, secret)
-        self.bucket = boto.s3.bucket.Bucket(self.conn, bucket_name)
+        self.session = boto3.Session(aws_access_key_id=key, aws_secret_access_key=secret)
+        self.s3_client = self.session.client('s3')
 
     @property
     def name(self):
         return "s3"
 
-    def key(self, hash):
-        return boto.s3.key.Key(self.bucket, "{}/{}".format(hash[:2], hash[2:]))
+    def get_remote_file_name(self, hash):
+        return "{}/{}".format(hash[:2], hash[2:])
 
     def push(self, file, hash, cb=None):
-        self.key(hash).set_contents_from_file(file, cb=cb)
+        self.s3_client.upload_file(file.name, self.bucket, self.get_remote_file_name(hash), Callback=cb)
 
     def pull(self, file, hash, cb=None):
-        self.key(hash).get_contents_to_file(file, cb=cb)
+        self.s3_client.download_file(self.bucket, self.get_remote_file_name(hash), file.name, Callback=cb)
 
     def exists(self, hash):
-        return self.key(hash).exists()
+        exists = False
 
+        try:
+            self.s3_client.head_object(Bucket=self.bucket, Key=self.get_remote_file_name(hash))
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                exists = False
+            else:
+                raise e
+        else:
+            exists = True
+
+        return exists


### PR DESCRIPTION
These patches port the s3 backend to the new API and provide a way to select a profile name. See that for the profile name you might just want to use it without setting any key since they might be set in ~/.aws/credentials