### PR TITLE
Fixed bug where old string formatting wasn't updated completely.

### DIFF
--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -133,7 +133,7 @@ class ProgressPercentage(object):
             percentage = (self.seen_so_far / self.size) * 100
             sys.stdout.write("\r{}  {} / {}  ({: <2.0%})".format(self.filename, self.seen_so_far, self.size, percentage))
         else:
-            sys.stdout.write("\r{}  {}" % (self.filename, self.seen_so_far))
+            sys.stdout.write("\r{}  {}".format(self.filename, self.seen_so_far))
         sys.stdout.flush()
 
 def pathnames():


### PR DESCRIPTION
Ran into this while using bigstore.  This causes the git bigstore pull to crash since it doesn't know how to handle the parameters.