### PR TITLE
Add install_requires to setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,7 @@ Requirements
 Configuration
 -------------
 
-First, install the requirements via pip.
-
-    pip install gitpython==0.3.2.RC1 boto==2.8.0 python-dateutil==1.5 pytz==2012h python-cloudfiles==1.7.10
-
-Then, install bigstore.
+First, install bigstore.
 
     pip install git-bigstore
 

--- a/bigstore/metadata.py
+++ b/bigstore/metadata.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __author__ = "Dan Loewenherz"
 __copyright__ = "Copyright 2015, Lionheart Software"
 __maintainer__ = "Dan Loewenherz"

--- a/setup.py
+++ b/setup.py
@@ -57,5 +57,13 @@ setup(
     scripts=[
         'bin/git-bigstore',
     ],
+    install_requires=[
+        'gitpython<2',
+        'boto',
+        'boto3',
+        'python-dateutil',
+        'pytz',
+        'python-cloudfiles',
+    ],
 )
 


### PR DESCRIPTION
This makes requirements get installed automatically by pip.  I also noticed some hanging issues when using `gitpython>=2`, so it depends on the older version.