### PR TITLE
Make `git bigstore pull` work with read-only access

### DIFF
--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -71,7 +71,7 @@ def config(name):
     :return: str or None
     """
     try:
-        return g().config(name, file=os.path.join(toplevel_dir, config_filename))
+        return g().config(name, file=config_filename)
     except git.exc.GitCommandError:
         return None
 

--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -324,9 +324,18 @@ def pull():
 
                         break
 
-    sys.stderr.write("pushing bigstore metadata...")
-    g().push("origin", "refs/notes/bigstore")
-    sys.stderr.write("done\n")
+    if g().diff('refs/notes/bigstore', 'refs/notes/bigstore-remote'):
+        # Only push if something changed
+        sys.stderr.write('pushing bigstore metadata...')
+        try:
+            g().push('origin', 'refs/notes/bigstore')
+            sys.stderr.write('done\n')
+        except git.exc.GitCommandError as e:
+            if e.stderr and 'read only' in e.stderr:
+                sys.stderr.write('read only\n')
+            else:
+                # An error pushing during a pull is not fatal
+                sys.stderr.write('ERROR\n')
 
 
 def filter_clean():

--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -442,6 +442,8 @@ def log():
     entries = []
     for tree in trees:
         entry = g().ls_tree('-r', tree, filename)
+        if entry.strip() == '':
+            continue
         metadata, filename = entry.split('\t')
         _, _, sha = metadata.split(' ')
         try:

--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -184,6 +184,7 @@ def pathnames():
 
 
 def push():
+    assert_initialized()
     try:
         sys.stderr.write("pulling bigstore metadata...")
         g().fetch("origin", "refs/notes/bigstore:refs/notes/bigstore-remote", "--force")
@@ -270,6 +271,7 @@ def push():
 
 
 def pull():
+    assert_initialized()
     try:
         sys.stderr.write("pulling bigstore metadata...")
         g().fetch("origin", "refs/notes/bigstore:refs/notes/bigstore-remote", "--force")
@@ -528,3 +530,17 @@ def init():
     g().config("filter.bigstore-compress.smudge", "git-bigstore filter-smudge")
 
     mkdir_p(object_directory(default_hash_function_name))
+
+
+def assert_initialized():
+    """
+    Check the make sure `git bigstore init` has been called.
+    If not then print an error and exit(1)
+    """
+    try:
+        if g().config('filter.bigstore.clean') == 'git-bigstore filter-clean':
+            return  # repo config looks good
+    except git.exc.GitCommandError:
+        pass
+    sys.stderr.write('fatal: You must run `git bigstore init` first.\n')
+    sys.exit(1)


### PR DESCRIPTION
This patch:
   - Makes `git bigstore pull` work with read-only repo access
   - Makes `git bigstore (push|pull)` throw an error if the user forgot `git bigstore init`
   - Removes as redundant (but harmless) os.path.join from my last patch



