### PR TITLE
Update bigstore AWS credential requirements

### DIFF
--- a/bigstore/backends/s3.py
+++ b/bigstore/backends/s3.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from builtins import object
+import sys
+
 try:
     import boto3
     import botocore
@@ -20,10 +22,9 @@ except ImportError:
     pass
 
 class S3Backend(object):
-    def __init__(self, bucket_name, key=None, secret=None, profile_name=None):
+    def __init__(self, bucket_name):
         self.bucket = bucket_name
-        self.session = boto3.Session(aws_access_key_id=key, aws_secret_access_key=secret, profile_name=profile_name)
-        self.s3_client = self.session.client('s3')
+        self.s3_client = aws(type="client", service_name="s3")
 
     @property
     def name(self):
@@ -52,3 +53,78 @@ class S3Backend(object):
             exists = True
 
         return exists
+
+## Generic AWS helper functions, from https://gist.github.com/bkruger99/6bbaacf1e7fa49891d421d6a1a7ba9c9
+"""
+    Generic AWS Helper call class to setup a boto3 Session.  Now with assume role support.
+    Pass in 'type=' to do either 'client' or 'resource'
+    usage:
+    ec2 = aws(type='client', service_name='ec2')
+    sqs_resource = aws(type='resource', service_name='sqs', RoleArn='arn:aws:iam::012345678901:role/example-role',
+                       RoleSessionName='SomeSessionName')
+    This will allow for either using your ~/.aws credentials or allow you to override in the function calls.
+    Python 2 and 3 compatible without six.
+"""
+
+def aws(type='client', **kwargs):
+    """
+    This makes boto3 client connection. EC2 is the default service being used.
+    :param: type (str) - client type.  Either "resource" or "client" right now
+    :param: **kwargs - anything else passed in.
+    :returns: Your aws object type you requested.
+    """
+    myargs = {}
+    if 'service_name' not in kwargs:
+        print("You need to specify a service_name")
+        raise
+
+    myargs.update(**kwargs)
+    if 'RoleArn' in kwargs and 'RoleSessionName' in myargs:
+        stscreds = __role_arn_to_session(**myargs)
+        myargs.update(stscreds)
+
+    myargs = __stripargs(**myargs)
+    session = boto3.Session()
+    client = eval("session." + type)(**myargs)
+    return client
+
+
+# sts assume role
+# originally from: https://gist.github.com/gene1wood/938ff578fbe57cf894a105b4107702de
+# slightly modified.
+def __role_arn_to_session(**args):
+    """
+    Pass in at least "RoleArn" and "RoleSessionName" with your args in the 'aws' function above.
+    """
+    clientargs = __stripargs(**args)
+    stsargs = __stripargs(sts=True, **args)
+    clientargs['service_name'] = 'sts'
+    client = boto3.client(**clientargs)
+    response = client.assume_role(**stsargs)
+    return {
+        'aws_access_key_id': response['Credentials']['AccessKeyId'],
+        'aws_secret_access_key': response['Credentials']['SecretAccessKey'],
+        'aws_session_token': response['Credentials']['SessionToken']}
+
+
+# Used to strip out STS arguments.
+def __stripargs(sts=False, **args):
+    stsTuple = ('RoleArn', 'RoleSessionName', 'Policy', 'DurationSeconds', 'ExternalId', 'SerialNumber', 'TokenCode')
+    clientargs = dict(args)
+    stsargs = {}
+    # Check if python 3 or newer. If not, then it's probably 2.
+    if sys.version_info.major >= 3:
+        for k,v in args.items():
+            if k in stsTuple:
+                stsargs[k] = v
+                del clientargs[k]
+    else:
+        for k, v in args.iteritems():
+            if k in stsTuple:
+                stsargs[k] = v
+                del clientargs[k]
+
+    if sts is not True:
+        return clientargs
+    else:
+        return stsargs

--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -103,10 +103,7 @@ def default_backend():
 def backend_for_name(name):
     if name == 's3':
         bucket_name = config('bigstore.s3.bucket')
-        access_key_id = config('bigstore.s3.key')
-        secret_access_key = config('bigstore.s3.secret')
-        profile_name = config('bigstore.s3.profile-name')
-        return S3Backend(bucket_name, access_key_id, secret_access_key, profile_name)
+        return S3Backend(bucket_name)
     elif name == 'cloudfiles':
         username = config('bigstore.cloudfiles.username')
         api_key = config('bigstore.cloudfiles.key')

--- a/bigstore/bigstore.py
+++ b/bigstore/bigstore.py
@@ -103,6 +103,13 @@ def default_backend():
 def backend_for_name(name):
     if name == 's3':
         bucket_name = config('bigstore.s3.bucket')
+        # Backward compatibility, but not suggested.
+        # If we don't have both key and secret, don't bother.
+        if config('bigstore.s3.key') and config('bigstore.s3.secret'):
+            os.environ["AWS_ACCESS_KEY_ID"] = config('bigstore.s3.key')
+            os.environ["AWS_SECRET_ACCESS_KEY"] = config('bigstore.s3.secret')
+        if config('bigstore.s3.profile-name'):
+            os.environ["AWS_PROFILE"] = config('bigstore.s3.profile-name')
         return S3Backend(bucket_name)
     elif name == 'cloudfiles':
         username = config('bigstore.cloudfiles.username')
@@ -458,22 +465,11 @@ def request_rackspace_credentials():
 
 def request_s3_credentials():
     print()
-    print("Enter your Amazon S3 Credentials")
-    print()
+    print("Enter your Amazon S3 Bucket")
+    print("Credentials are now done by ENV Variables.\n")
     s3_bucket = input("Bucket Name: ")
-    s3_key = input("Access Key: ")
-    s3_secret = input("Secret Key: ")
-    s3_profile_name = input("Profile Name: ")
-
     g().config("bigstore.backend", "s3", file=config_filename)
     g().config("bigstore.s3.bucket", s3_bucket, file=config_filename)
-    if s3_key != '':
-        g().config("bigstore.s3.key", s3_key, file=config_filename)
-    if s3_secret != '':
-        g().config("bigstore.s3.secret", s3_secret, file=config_filename)
-    if s3_profile_name != '':
-        g().config("bigstore.s3.profile-name", s3_profile_name, file=config_filename)
-
 
 def request_google_cloud_storage_credentials():
     print()
@@ -541,26 +537,11 @@ def init():
             choice = input("Enter your choice here: ")
 
         if choice == "1":
+            print("""New Behavior: Use standard aws env variables for credentials or machine role.
+                   Assume-role is now supported in aws profiles.""")
             try:
                 g().config("bigstore.s3.bucket", file=config_filename)
             except git.exc.GitCommandError:
-                request_s3_credentials()
-
-            keys_set = True
-            try:
-                g().config("bigstore.s3.key", file=config_filename)
-                g().config("bigstore.s3.secret", file=config_filename)
-            except git.exc.GitCommandError:
-                keys_set = False
-
-            profile_name_set = True
-            try:
-                g().config("bigstore.s3.profile-name", file=config_filename)
-            except git.exc.GitCommandError:
-                profile_name_set = False
-
-            if not keys_set and not profile_name_set:
-                print("Either the secret keys are not set or the profile name is not set")
                 request_s3_credentials()
         elif choice == "2":
             try:


### PR DESCRIPTION
You can use this to assume a role, use a node role, or if you need to use keys or profile, just set your env vars.   Backward compatibility is present but discouraged.


```

## Using an assumed role, all credential traces removed from .bigstore file.
bkruger$ export | grep AWS
declare -x AWS_PROFILE="dev_role"
declare -x AWS_SDK_LOAD_CONFIG="1"

bkruger$ grep -A4 "dev_role" ~/.aws/credentials
[profile dev_role]
region = us-west-2
role_arn = arn:aws:iam::XXXXXXX:role/XXXXXXX
source_profile = default

bkruger$ cat .bigstore
[bigstore]
	backend = s3
[bigstore "s3"]
	bucket = bigstore2350asdgfadsg
	
	
bkruger$ git bigstore init
Reading credentials from .bigstore configuration file.

bkruger$ git bigstore pull
pulling bigstore metadata...done
path/to/data/somefile.json  111111111
...


## Setting profile that uses aws keys.  Credentials removed from .bigstore file.
bkruger$ grep -A4 "dev_keys" ~/.aws/credentials
[profile dev_keys]
region = us-west-2
aws_access_key_id = redacted
aws_secret_access_key = redacted


bkruger$ export AWS_PROFILE="dev_keys"
bkruger$ git bigstore pull
pulling bigstore metadata...done
path/to/data/somefile.json  111111111
....

## Profile set in .bigstore file
bkruger$ export | grep AWS
declare -x AWS_SDK_LOAD_CONFIG="1"

bkruger$ cat .bigstore
[bigstore]
	backend = s3
[bigstore "s3"]
	bucket = bigstore2350asdgfadsg
	profile-name = dev_keys

bkruger$ git bigstore pull
pulling bigstore metadata...done
path/to/data/somefile.json  111111111
....

## Settings that have access key and secret key in the .bigstore profile:
Not tested.  This encourages bad behavior and potentially of checking keys into a git repo.
With AWS, we don't need this.
```